### PR TITLE
Persisting configuration on MySQL

### DIFF
--- a/config.go
+++ b/config.go
@@ -1,9 +1,12 @@
 package config
 
-import "os"
+import (
+	"context"
+	"os"
+)
 
-// Provider can be set to configure which Source to use.
-var Provider = func(args ...interface{}) (src Source) {
+// FromEnv gives us a Source from the system's environment.
+func FromEnv() (src Source) {
 	src.SourceImpl = EnvSourceImpl{}
 	return
 }
@@ -13,25 +16,31 @@ type Source struct {
 	SourceImpl
 }
 
-// GetDef returns the value for a key if found, else the passed default value.
-func (src Source) GetDef(key string, def string) (value string) {
-	if value = src.SourceImpl.Get(key); len(value) > 0 {
+// GetDef returns the value for a key if non-empty and no error, else the passed default
+// value.
+func (src Source) GetDef(
+	ctx context.Context, key string, def string,
+) (value string, err error) {
+	if value, err = src.SourceImpl.Get(ctx, key); err != nil || value == "" {
+		value = def
 		return
 	}
 
-	value = def
 	return
 }
 
 // SourceImpl is an interface to implement for any configuration system.
 type SourceImpl interface {
-	Get(key string) (value string)
+	Get(ctx context.Context, key string) (value string, err error)
 }
 
 // EnvSourceImpl is an implementation of SourceImpl using os.Getenv.
 type EnvSourceImpl struct{}
 
 // Get a key from the environment.
-func (src EnvSourceImpl) Get(key string) (value string) {
-	return os.Getenv(key)
+func (src EnvSourceImpl) Get(
+	ctx context.Context, key string,
+) (value string, err error) {
+	value = os.Getenv(key)
+	return
 }

--- a/mysql.go
+++ b/mysql.go
@@ -1,0 +1,55 @@
+package config
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/angadn/tabular"
+)
+
+// FromMySQL gives us a Source for MySQL.
+func FromMySQL(
+	ctx context.Context, db *sql.DB,
+) (sourceImpl SourceImpl, err error) {
+	if err = db.PingContext(ctx); err != nil {
+		return
+	}
+
+	sourceImpl = MySQLSource{db}
+	return
+}
+
+// MySQLSource is an implementation of SourceImpl using MySQL.
+type MySQLSource struct {
+	db *sql.DB
+}
+
+// Get a key from the database.
+func (src MySQLSource) Get(ctx context.Context, key string) (value string, err error) {
+	err = src.db.QueryRowContext(ctx, table.Selection(
+		"SELECT %s FROM `configurations` WHERE `name` = ?",
+	), key).Scan(&tabular.Scapegoat{}, &value)
+
+	return
+}
+
+// Set a key in the database.
+func (src MySQLSource) Set(ctx context.Context, key string, value string) (err error) {
+	_, err = src.db.ExecContext(
+		ctx,
+		table.Insertion("%s ON DUPLICATE KEY UPDATE `value` = VALUES(`value`)"),
+		key,
+		value,
+	)
+
+	return
+}
+
+// table is a tabular representation of Configurations, and helps us persist them in an
+// SQL database.
+var table = tabular.New(
+	"configurations",
+
+	"name",
+	"value",
+)


### PR DESCRIPTION
**Change-log:**
* Added a MySQL Configuration Source
* Simplifying Providers to just Factory methods prefixed with `From`, as the pseudo-generic signature was a strange one to read and wasn't really very exploitable
* Adding a Context for getting configuration as this package is to go beyond simple setups and retrieving configuration via some sort of networking. In such cases where time-outs etc. become a factor, cancellations might be helpful
* Returning errors in the spirit of allowing the consumer to choose whether to report and suppress an error or to propagate it upwards

